### PR TITLE
Correction of marine_acoustics DVL message packing.

### DIFF
--- a/include/dvl_a50/dvl_a50.hpp
+++ b/include/dvl_a50/dvl_a50.hpp
@@ -37,7 +37,7 @@ public:
         int speed_of_sound,
         bool acoustic_enabled,
         bool led_enabled,
-        int mountig_rotation_offset,
+        int mounting_rotation_offset,
         std::string range_mode);
 
     void set_speed_of_sound(int speed_of_sound);

--- a/src/dvl_a50_ros2.cpp
+++ b/src/dvl_a50_ros2.cpp
@@ -246,14 +246,19 @@ public:
             velocity_report.beam_ranges_valid = true;
             velocity_report.beam_velocities_valid = res["velocity_valid"];
 
+            velocity_report.num_good_beams = 0;
             // Beam specific data
             for (size_t beam = 0; beam < 4; beam++)
             {
-                velocity_report.num_good_beams += bool(res["transducers"][beam]["beam_valid"]);
-                velocity_report.range = res["transducers"][beam]["distance"];
+                if (res["transducers"][beam]["beam_valid"])
+                {
+                    velocity_report.num_good_beams++;
+                }
+
+                velocity_report.range[beam] = double(res["transducers"][beam]["distance"]);
                 //velocity_report.range_covar
-                velocity_report.beam_quality = res["transducers"][beam]["rssi"];
-                velocity_report.beam_velocity = res["transducers"][beam]["velocity"];
+                velocity_report.beam_quality[beam] = res["transducers"][beam]["rssi"];
+                velocity_report.beam_velocity[beam] = res["transducers"][beam]["velocity"];
                 //velocity_report.beam_velocity_covar
             }
 


### PR DESCRIPTION
Once we activate the acoustic_enabled flag. The a50 start sending another message. This one used for publishing the velocity topic. However the marice_acoustic message is improperly accessed while packing its fields with the received message, causing the code to throw an error. Field structure were using the previous message format.